### PR TITLE
Improve tag accessibility and styling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,7 +7,7 @@ title = "Alperen Keles"
 
 author = "Alperen Keles"
 # Generate a feed file at the root of the site
-generate_feed = true
+generate_feeds = true
 
 [extra]
 theme = "toggle"

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -5,11 +5,6 @@ sort_by = "date"
 insert_anchor_links = "heading"
 template = "posts.html"
 
-[taxonomies]
-tags = ["tags"]
-language = "language"
-
-
 [extra]
 comment = false
 +++

--- a/themes/apollo/sass/parts/_tags.scss
+++ b/themes/apollo/sass/parts/_tags.scss
@@ -14,13 +14,18 @@
   }
 
   a:hover {
-    color: var(--hover_color);
+    color: var(--hover-color);
     background-color: var(--primary-color);
   }
 
-  a::before {
-    content: "🏷 "; /* Ensure there's a space after the emoji for spacing */
+  a:focus,
+  a:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
+  .tag-icon {
     display: inline;
-    white-space: nowrap !important;
+    margin-right: 0.25em;
   }
 }

--- a/themes/apollo/templates/macros/macros.html
+++ b/themes/apollo/templates/macros/macros.html
@@ -94,7 +94,7 @@
                 {%- set sep = "&nbsp;" -%}
             {% endif -%}
             {%- for tag in page.taxonomies.tags %}
-                <a class="post-tag" href="{{ get_taxonomy_url(kind='tags', name=tag) | safe }}">#{{ tag }}</a>
+                <a class="post-tag" href="{{ get_taxonomy_url(kind='tags', name=tag) | safe }}" aria-label="Tag: {{ tag }}"><span class="tag-icon" aria-hidden="true">🏷</span>#{{ tag }}</a>
                 {%- if not loop.last %}{{ sep | safe }}{% endif -%}
             {% endfor -%}
         </span>
@@ -141,7 +141,7 @@
                             <span class="tags-label"> :: Tags:</span>
                             <span class="tags">
                                 {%- for tag in page.taxonomies.tags %}
-                                    <a href="{{ get_taxonomy_url(kind='tags', name=tag) }}" class="post-tag">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+                                    <a href="{{ get_taxonomy_url(kind='tags', name=tag) }}" class="post-tag" aria-label="Tag: {{ tag }}"><span class="tag-icon" aria-hidden="true">🏷</span>{{ tag }}</a>{% if not loop.last %}, {% endif %}
                                 {% endfor %}
                             </span>
                     {% endif %}


### PR DESCRIPTION
Updated tag links to include an accessible label and a tag icon for better UX. Enhanced tag focus styles in SCSS for improved accessibility. Fixed a typo in config.toml and cleaned up unused taxonomies in posts index.

<img width="979" height="192" alt="image" src="https://github.com/user-attachments/assets/15fa8638-730f-4580-b48d-e92abbc420a7" />
<img width="992" height="184" alt="image" src="https://github.com/user-attachments/assets/8859aa7b-d0ca-4f8a-bb94-1dd0cb6e98eb" />

Resources I used for fixes:
https://www.getzola.org/documentation/content/taxonomies/
https://www.getzola.org/documentation/templates/feeds/

